### PR TITLE
added footer to the blog

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -18,7 +18,7 @@
     {{ content }}
   </section>
     
-  
+   {% include footer.html%}
 </body>
 
 </html>


### PR DESCRIPTION
the blog didn't have a footer included to it, so when someone is on the blog page and click contact nav button it would scroll down to end of the page and no footer were shown';